### PR TITLE
Fix invalid IDs making created items unsellable

### DIFF
--- a/SPT-AKI Profile Editor/Core/ExtMethods.cs
+++ b/SPT-AKI Profile Editor/Core/ExtMethods.cs
@@ -19,7 +19,7 @@ namespace SPT_AKI_Profile_Editor.Core
                 var getTime = DateTime.Now;
                 Random rnd = new();
                 var random = rnd.Next(100000000, 999999999).ToString();
-                var retVal = $"I{getTime:MM}{getTime:dd}{getTime:HH}{getTime:mm}{getTime:ss}{random}";
+                var retVal = $"{getTime:MM}{getTime:dd}{getTime:HH}{getTime:mm}{getTime:ss}{random}";
                 var sign = MakeSign(24 - retVal.Length, rnd);
                 id = retVal + sign;
             } while (ids.Contains(id));
@@ -29,7 +29,7 @@ namespace SPT_AKI_Profile_Editor.Core
         private static string MakeSign(int length, Random random)
         {
             var result = "";
-            var characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+            var characters = "0123456789abcdef";
             for (int i = 0; i < length; i++)
                 result += characters.ElementAt((int)Math.Floor(random.NextDouble() * characters.Length));
             return result;


### PR DESCRIPTION
Right now the items created using the profile editor are unsellable because the vendors will notice the that the ids are invalid because they contain non-hexadecimal characters.  
I propose fixing it by stop using a "I" at the start of the IDs and make the "sign" that's appended at the end of the ids contain only hexadecimal characters.